### PR TITLE
Replace compatibility synonym with canonical name

### DIFF
--- a/mutt/muttrc
+++ b/mutt/muttrc
@@ -128,7 +128,7 @@ macro pager \Cu "|urlview<enter>" "call urlview to open links"
 
 # Compose View Options -------------------------------
 set realname = "George Hickman"      # who am i?
-set envelope_from                    # which from?
+set use_envelope_from                # which from?
 set sig_dashes                       # dashes before sig
 set edit_headers                     # show headers when composing
 set fast_reply                       # skip to compose when replying


### PR DESCRIPTION
The `envelope_from` setting was [renamed to `use_envelope_from`](https://gitlab.com/muttmua/mutt/commit/6152d9060085b8f8b4239bef2a06384c815518ad). It had continued to work because a backwards-compatible shim was added.

This is ultimately a cosmetic change, but as I was using this file as a reference, and as [`envelope_from` is not mentioned in the docs](http://www.mutt.org/doc/manual/#use-envelope-from), I thought it might be handy to tweak it.

See [the change log](https://gitlab.com/muttmua/mutt/blob/master/ChangeLog#L16648).